### PR TITLE
Prevent Exception if boolean value is passed

### DIFF
--- a/Classes/Provider/Settings.php
+++ b/Classes/Provider/Settings.php
@@ -177,7 +177,9 @@ class Tx_T3chimp_Provider_Settings {
             $this->settings = array_merge($this->settings, $this->configurationManager->getConfiguration(Tx_Extbase_Configuration_ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK));
             $global = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey]);
             $global = $this->cleanSettingKeys($global);
-            self::$settingsCache[$this->extKey] = array_merge($this->settings, $global);
+            if(is_array($global)) {
+               self::$settingsCache[$this->extKey] = array_merge($this->settings, $global); 
+            }
         }
 
         $this->settings = self::$settingsCache[$this->extKey];


### PR DESCRIPTION
In some cases, a Boolean value is passed, which array_merge can not handle.
