### PR TITLE
Fixed argument type hinting

### DIFF
--- a/Classes/Scheduler/SyncToMailChimpFieldProvider.php
+++ b/Classes/Scheduler/SyncToMailChimpFieldProvider.php
@@ -230,7 +230,7 @@ class SyncToMailChimpFieldProvider implements AdditionalFieldProviderInterface {
      * @param AbstractTask $task Reference to the scheduler backend module
      * @return void
      */
-    public function saveAdditionalFields(array $submittedData, AbstractTask $task) {
+    public function saveAdditionalFields(array $submittedData, \TYPO3\CMS\Scheduler\Task\AbstractTask $task) {
         /** @var SyncToMailChimpTask $task */
         $task->setListId($submittedData['listId']);
         GeneralUtility::devLog('T3Chimp List ID ' . $submittedData['listId'], 't3chimp');


### PR DESCRIPTION
The incorrect type hinting in `SyncToMailChimpFieldProvider::saveAdditionalFields()` led to a PHP Fatal error in two of our TYPO3 6.1.7 installations (invalid namespace).

But more importantly, **the whole Scheduler task setup seems to get broken by the t3chimp** extension (tested in two separate TYPO3 6.1.7 installations). I did not have the time to dig into the code any further though ... Can you confirm this?
