### PR TITLE
Fix for Provider/FlexFormValues on a multi domain installation.

### DIFF
--- a/Classes/Provider/FlexFormValues.php
+++ b/Classes/Provider/FlexFormValues.php
@@ -41,8 +41,12 @@ class FlexFormValues {
 
     protected function initialize($extKey) {
         /** @var BackendConfigurationManager $config */
-        $config = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
-        $setup = $config->getTypoScriptSetup();
+        //$config = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
+        //$setup = $config->getTypoScriptSetup();
+        
+        // The code above doesn't respect our setup in BE mode (TYPO3 6.1.10).
+        $setup = $this->getTypoScriptSetup();
+        
         $setup = $setup['plugin.']['tx_' . $extKey . '.'];
         $tsConfig = BackendUtility::getPagesTSconfig($this->getCurrentPageId());
         $tsConfig = $tsConfig['plugin.']['tx_' . $extKey . '.'];
@@ -58,11 +62,56 @@ class FlexFormValues {
 
         $this->api = new MailChimpApi($apiKey);
     }
+    
+    /**
+     * RHA
+     *
+     * Gets the typoscript setup of the current page.
+     * This code is taken from the extbase core and slightly modified (TYPO3 6.1.10). 
+     *
+     * @see http://api.typo3.org/typo3cms/61/html/class_t_y_p_o3_1_1_c_m_s_1_1_extbase_1_1_configuration_1_1_abstract_configuration_manager.html#a53db9b74f2a65ef2ddbddbc782937fca
+     * @return array $setup
+     */
+    protected function getTypoScriptSetup (){
+		$pageId = $this->getCurrentPageId();
+		
+		$template = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\TemplateService');
+		// do not log time-performance information
+		$template->tt_track = 0;
+		// Explicitly trigger processing of extension static files
+		$template->setProcessExtensionStatics(TRUE);
+		$template->init();
+		// Get the root line
+		$rootline = array();
+		if ($pageId > 0) {
+			$sysPage = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+			// Get the rootline for the current page
+			$rootline = $sysPage->getRootLine($pageId, '', TRUE);
+		}
+		// This generates the constants/config + hierarchy info for the template.
+		$template->runThroughTemplates($rootline, 0);
+		$template->generateConfig();
+		
+		return $template->setup;
+    }
 
     protected function getCurrentPageId() {
         $pageId = (integer)GeneralUtility::_GP('id');
         if ($pageId > 0) {
             return $pageId;
+        }
+        
+        // RHA
+        // Get current page id when editing an content element in the backend.
+        // &edit[tt_content][1486,]=edit
+        $edit = GeneralUtility::_GP('edit');
+        if (is_array($edit) && isset($edit['tt_content'])){
+        	$contentElementUids = array_shift(array_keys($edit['tt_content']));
+	        $contentElementUidsList = \TYPO3\CMS\Core\Utility\GeneralUtility::intExplode(',', $contentElementUids, TRUE);
+	        $pageRecords = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('pid', 'tt_content', 'uid IN(' . implode(',', $contentElementUidsList) . ')', '', '', '1');
+	        if (count($pageRecords)){
+		        return $pageRecords[0]['pid'];
+	        }
         }
 
         // get current site root


### PR DESCRIPTION
BackendConfigurationManager->getTypoScriptSetup() can not found the correct rootline because it only checks for the GET parameter id. When editing a plugin there is no such parameter. Instead we have to look up on which page the content element is and return this id.
