### PR TITLE
Prevent form validation in scheduler to check for captcha

### DIFF
--- a/Classes/Scheduler/SyncToMailChimpTask.php
+++ b/Classes/Scheduler/SyncToMailChimpTask.php
@@ -53,6 +53,7 @@ class SyncToMailChimpTask extends Base {
         /** @var Form $form */
         $form = $this->objectManager->get('MatoIlic\\T3Chimp\\MailChimp\\Form', $fieldDefinitions, $this->listId);
         $form->setInterestGroupings($interestGroupings);
+        $form->setDisableCaptcha(TRUE);
 
         $groupingFields = array();
         foreach($interestGroupings as $grouping) {


### PR DESCRIPTION
When running in CLI mode/scheduler there is no user involved and thus the captcha can never successfully validate.
This causes the user sync to never subscribe users to the list.
