### PR TITLE
sync back unsubscriptions from mailchimp to typo3

### DIFF
--- a/Classes/Scheduler/Base.php
+++ b/Classes/Scheduler/Base.php
@@ -146,6 +146,19 @@ abstract class Base extends AbstractTask {
     }
 
     /**
+     * @param string $listId
+     * @return array
+     */
+    protected function retrieveUnsubscribers($listId) {
+        $unsubscribers = array();
+        foreach($this->mailChimp->getUnsubscribersFor($listId) as $unsubscriber) {
+            $unsubscribers[$unsubscriber['email']] = $unsubscriber;
+        }
+
+        return $unsubscribers;
+    }
+
+    /**
      * @param $key the key for the label
      * @param NULL|array $arguments
      * @param string $default

--- a/Classes/Scheduler/SyncBackFromMailChimpTask.php
+++ b/Classes/Scheduler/SyncBackFromMailChimpTask.php
@@ -49,6 +49,13 @@ class SyncBackFromMailChimpTask extends Base {
             foreach($subscribers as $subscriber) {
                 $this->userRepo->updateNewsletterFlag($this->emailField, $subscriber['email'], 1);
             }
+
+            $unsubscribers = $this->retrieveUnsubscribers($this->listId);
+
+            foreach($unsubscribers as $unsubscriber) {
+                $this->userRepo->updateNewsletterFlag($this->emailField, $unsubscriber['email'], 0);
+            }
+
         } catch (Exception $e) {
             $GLOBALS['BE_USER']->writeLog(4, 0, 1, 0, '[t3chimp]: ' . $e->getMessage());
             $GLOBALS['BE_USER']->writeLog(4, 0, 1, 0, '[t3chimp]: ' . $e->getTraceAsString());

--- a/Classes/Service/MailChimp.php
+++ b/Classes/Service/MailChimp.php
@@ -228,6 +228,28 @@ class MailChimp implements SingletonInterface {
         return $subscribers;
     }
 
+    /**
+     * @param string $listId
+     * @return array
+     */
+    public function getUnsubscribersFor($listId) {
+        $unsubscribers = array();
+
+        $page = 0;
+        $limit = 100;
+        do {
+            $response = $this->api->lists->members($listId, 'unsubscribed', array(
+                'start' => $page * $limit,
+                'limit' => $limit
+            ));
+            $page++;
+            $unsubscribers = array_merge($unsubscribers, $response['data']);
+        } while(count($unsubscribers) < $response['total']);
+
+        return $unsubscribers;
+    }
+
+
     public function getSubscriptionInfo($email) {
         $info = $this->api->lists->memberInfo(
             $this->settingsProvider->get('subscriptionList'),


### PR DESCRIPTION
If a user removes subscription on the platform mailchimp, then the typo3 database field subscribed_to_newsletter will change now from 1 to 0.
